### PR TITLE
Make CONSOLE_UNIQUE_ID changeable in config file

### DIFF
--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -133,6 +133,10 @@ use_virtual_sd =
 # 0: Old 3DS (default), 1: New 3DS
 is_new_3ds =
 
+# The console unique id that Citra will use during emulation
+# 3735929054: 0xDEADC0DE (default)
+console_id =
+
 # The system region that Citra will use during emulation
 # -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
 region_value =

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -120,6 +120,8 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("System");
     Settings::values.is_new_3ds = qt_config->value("is_new_3ds", false).toBool();
+    Settings::values.console_id =
+        qt_config->value("console_id", Settings::CONSOLE_ID_DEFAULT).toULongLong();
     Settings::values.region_value =
         qt_config->value("region_value", Settings::REGION_VALUE_AUTO_SELECT).toInt();
     qt_config->endGroup();
@@ -255,6 +257,7 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("System");
     qt_config->setValue("is_new_3ds", Settings::values.is_new_3ds);
+    qt_config->setValue("console_id", Settings::values.console_id);
     qt_config->setValue("region_value", Settings::values.region_value);
     qt_config->endGroup();
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -88,6 +88,7 @@ struct Values {
 
     // System Region
     int region_value;
+    u64 console_id;
 
     // Renderer
     bool use_hw_renderer;
@@ -131,6 +132,8 @@ struct Values {
 // a special value for Values::region_value indicating that citra will automatically select a region
 // value to fit the region lockout info of the game
 static constexpr int REGION_VALUE_AUTO_SELECT = -1;
+
+static constexpr u64 CONSOLE_ID_DEFAULT = 0xDEADC0DE;
 
 void Apply();
 }


### PR DESCRIPTION
This is a alternative approach to #4 

This will add a entry to the config file to set the console_unique_id. 
One draw back is that it will remove the console_unique_id from the config_save_file, since there is no way a change in the config_file can trigger a rewrite the config_save_file.
This will cause the issue that accessing the console_unique_id directly and not through GenHashConsoleUnique will fail to get the correct console_unique_id.

All in all i like #4 more, since it is closer to the real behavior of a 3DS